### PR TITLE
Multiprocess Push + Cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "http-call": "^5.1.4",
     "inquirer": "^6.0.0",
     "node-fetch": "^2.1.2",
-    "tslib": "^1"
+    "parse-procfile": "^0.0.2",
+    "tslib": "^1",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@heroku-cli/schema": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "inquirer": "^6.0.0",
     "node-fetch": "^2.1.2",
     "parse-procfile": "^0.0.2",
+    "tmp-promise": "^1.0.5",
     "tslib": "^1",
     "yamljs": "^0.3.0"
   },

--- a/src/commands/_container/push.ts
+++ b/src/commands/_container/push.ts
@@ -16,7 +16,7 @@ const tmp = require('tmp-promise')
 const YAML = require('yamljs')
 
 // cleanup tmp files even if an exception is caught
-tmp.setGracefulCleanup();
+tmp.setGracefulCleanup()
 
 type ReleaseBody = {
   addon_plan_names: [string],

--- a/src/commands/_container/push.ts
+++ b/src/commands/_container/push.ts
@@ -76,20 +76,21 @@ $ heroku _container:push`,
     await Sanbashi.cmd('tar', ['-xf', `${flags.app}.slug`, './app/release.yml'])
     let processes: ProcessTypes = {}
     let releaseYml = YAML.load('app/release.yml')
-    for (let processType in releaseYml.default_process_types) {
+    Object.keys(releaseYml.default_process_types).forEach((processType: string) => {
       processes[processType] = ''
-    }
+    })
     if (fs.existsSync('Procfile')) {
       let procfile = procfileParse(fs.readFileSync('Procfile', 'utf8'))
-      for (let processType in procfile) {
+      Object.keys(procfile).forEach((processType: string) => {
         processes[processType] = ''
-      }
+      })
     }
 
     // only try to login on the first push
     let firstRun = true
+    let processTypes = Object.keys(processes)
 
-    for (let processType in processes) {
+    for (let processType of processTypes) {
       cli.styledHeader(`Deploying process '${processType}'`)
       let registryImage = `${registry}/${flags.app}/${processType}`
       cli.action.start(`Tagging image '${registryImage}'`)
@@ -109,9 +110,9 @@ $ heroku _container:push`,
       try {
         await Sanbashi.pushImage(registryImage, pushOptions)
       } catch (err) {
-        if (firstRun && err.error.includes("no basic auth credentials")) {
+        if (firstRun && err.error.includes('no basic auth credentials')) {
           // docker login
-          cli.action.start("Not logged into the registry, trying to login")
+          cli.action.start('Not logged into the registry, trying to login')
           let password = this.heroku.auth
           if (!password) throw new Error('not logged in')
 
@@ -136,7 +137,7 @@ $ heroku _container:push`,
               await Sanbashi.cmd('docker', args, {output: true})
             }
           } catch (err) {
-            cli.error(`Error: docker login exited with ${err}`, 1)
+            cli.error(`Error: docker login exited with ${err}`)
           }
           cli.action.stop()
 

--- a/src/sanbashi.js
+++ b/src/sanbashi.js
@@ -128,6 +128,11 @@ Sanbashi.imageID = function (tag) {
     .then(id => id.trimRight()) // Trim the new line at the end of the string
 }
 
+Sanbashi.tag = function (source, target) {
+  return Sanbashi
+    .cmd('docker', ['tag', source, target])
+}
+
 Sanbashi.cmd = function (cmd, args, options = {}) {
   debug(cmd, args)
   let stdio = [process.stdin, process.stdout, process.stderr]

--- a/src/sanbashi.js
+++ b/src/sanbashi.js
@@ -95,9 +95,9 @@ Sanbashi.buildImage = function (dockerfile, resource, buildArg, path) {
   return Sanbashi.cmd('docker', args)
 }
 
-Sanbashi.pushImage = function (resource) {
+Sanbashi.pushImage = function (resource, options = {}) {
   let args = ['push', resource]
-  return Sanbashi.cmd('docker', args)
+  return Sanbashi.cmd('docker', args, options)
 }
 
 Sanbashi.pullImage = function (resource) {

--- a/src/sanbashi.js
+++ b/src/sanbashi.js
@@ -142,6 +142,9 @@ Sanbashi.cmd = function (cmd, args, options = {}) {
   if (options.output) {
     stdio[1] = 'pipe'
   }
+  if (options.error) {
+    stdio[2] = 'pipe'
+  }
 
   return new Promise((resolve, reject) => {
     let child = Child.spawn(cmd, args, {stdio: stdio})
@@ -150,15 +153,27 @@ Sanbashi.cmd = function (cmd, args, options = {}) {
       child.stdin.end(options.input)
     }
     let stdout
+    let stderr
     if (child.stdout) {
       stdout = ''
       child.stdout.on('data', (data) => {
         stdout += data.toString()
       })
     }
+    if (child.stderr) {
+      stderr = ''
+      child.stderr.on('data', (data) => {
+        stderr += data.toString()
+      })
+    }
     child.on('exit', (code, signal) => {
-      if (signal || code) reject(signal || code)
-      else resolve(stdout)
+      if (signal || code) {
+        let error = {
+          code: signal || code,
+          error: stderr
+        }
+        reject(error)
+      } else resolve(stdout)
     })
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,6 +1798,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-procfile@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/parse-procfile/-/parse-procfile-0.0.2.tgz#0c283ecd447cafe0d925cd92884c95a1f7e7f734"
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -2623,6 +2627,13 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yargs-parser@^8.0.0:
   version "8.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -372,6 +372,10 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bluebird@^3.5.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2345,7 +2349,14 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
-tmp@^0.0.33:
+tmp-promise@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-1.0.5.tgz#3208d7fa44758f86a2a4c4060f3c33fea30e8038"
+  dependencies:
+    bluebird "^3.5.0"
+    tmp "0.0.33"
+
+tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   dependencies:


### PR DESCRIPTION
This update to `_container:push` adds the following improvements:

* supports all the process defined in the `Procfile` by the user as well as any set by the buildpack.
* during the first `docker push`, if an authentication error is detected try to login the user for them
* minimize the UI displayed to the user
![container-push3](https://user-images.githubusercontent.com/16457/42988853-cbe2ec80-8bc3-11e8-8785-0058689907f3.png)
