### PR TITLE
Port

### DIFF
--- a/src/commands/_container/run.ts
+++ b/src/commands/_container/run.ts
@@ -17,7 +17,8 @@ $ heroku _container:run`,
     app: flags.app({required: true}),
     'skip-stack-pull': flags.boolean(),
     type: flags.string({char: 't'}),
-    config: flags.boolean()
+    config: flags.boolean(),
+    port: flags.integer()
   }
 
   static args = [
@@ -44,6 +45,10 @@ $ heroku _container:run`,
 
     if (flags['skip-stack-pull']) {
       cmdArgs.push('--skip-stack-pull')
+    }
+
+    if (flags.port) {
+      cmdArgs.push(`--port=${flags.port}`)
     }
 
     if (flags.type) {


### PR DESCRIPTION
This adds a `port` flag to the `run` command in the CLI and passes it through to `tatara`. It also depends on [this PR](https://github.com/heroku/tatara/pull/15) to be merged in as well.